### PR TITLE
fix: should break the loop when connection has closed

### DIFF
--- a/ws_reverse_proxy.go
+++ b/ws_reverse_proxy.go
@@ -137,9 +137,12 @@ func (w *WSReverseProxy) ServeHTTP(ctx context.Context, c *app.RequestContext) {
 
 			var ce *websocket.CloseError
 			var hzce *hzws.CloseError
-			if !errors.As(err, &ce) || !errors.As(err, &hzce) {
+			if !errors.As(err, &ce) && !errors.As(err, &hzce) {
 				hlog.CtxErrorf(ctx, errMsg, err)
+				continue
 			}
+
+			break
 		}
 	}); err != nil {
 		hlog.CtxErrorf(ctx, "can not upgrade to websocket: %v", err)

--- a/ws_reverse_proxy_test.go
+++ b/ws_reverse_proxy_test.go
@@ -55,6 +55,7 @@ func TestProxy(t *testing.T) {
 
 	// proxy server
 	ps := server.Default(server.WithHostPorts(":7777"))
+	ps.NoHijackConnPool = true
 	ps.GET("/proxy", proxy.ServeHTTP)
 	go ps.Spin()
 
@@ -63,6 +64,7 @@ func TestProxy(t *testing.T) {
 	go func() {
 		// backend server
 		bs := server.Default()
+		bs.NoHijackConnPool = true
 		bs.GET("/", func(ctx context.Context, c *app.RequestContext) {
 			// Don't upgrade if original host header isn't preserved
 			host := string(c.Host())


### PR DESCRIPTION
#### What type of PR is this?

fix

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

The loop will never break( may cause memory leak )

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
